### PR TITLE
Spike of passing the arg values to the callback

### DIFF
--- a/test/intercepted_modules/intercept_config.ex
+++ b/test/intercepted_modules/intercept_config.ex
@@ -4,7 +4,7 @@ defmodule InterceptConfig do
   {InterceptedOnBefore1, :to_intercept, 0} => [before: {Before.Callback, :before, 1}],
   {InterceptedOnBefore2, :to_intercept, 0} => [before: {Before.Callback, :before, 1}],
   {InterceptedOnBefore2, :other_to_intercept, 0} => [before: {Before.Callback, :before, 1}],
-  {InterceptedOnBefore3, :other_to_intercept, 1} => [before: {Before.Callback, :before, 1}],
+  {InterceptedOnBefore3, :other_to_intercept, 1} => [before: {Before.Callback, :before_with_arg_values, 2}],
   {InterceptedOnBefore4, :to_intercept, 0} => [before: {Before.Callback, :before, 1}],
 
   # on after tests

--- a/test/intercepted_modules/intercepted_on_before.ex
+++ b/test/intercepted_modules/intercepted_on_before.ex
@@ -6,6 +6,14 @@ defmodule Before.Callback do
       end)
     "Doesn't influence the function at all"
   end
+
+  def before_with_arg_values({_module, _function, _arity} = mfa, arg_values) do
+    Agent.update(:before_test_process,
+      fn messages ->
+        [{Interceptor.Utils.timestamp(), mfa, arg_values} | messages]
+      end)
+    "Doesn't influence the function at all"
+  end
 end
 
 defmodule InterceptedOnBefore1 do

--- a/test/interceptor_on_before_test.exs
+++ b/test/interceptor_on_before_test.exs
@@ -54,14 +54,17 @@ defmodule InterceptorOnBeforeTest do
       {:ok, _pid} = spawn_agent()
 
       result = InterceptedOnBefore3.other_to_intercept(4)
+      # HEADERS
+      # {:other_to_intercept, [line: 35], [{:w, [line: 35], nil}]}
 
       callback_calls = get_agent_messages()
 
-      [{_intercepted_timestamp, intercepted_mfa}] = callback_calls
+      [{_intercepted_timestamp, intercepted_mfa, arg_values}] = callback_calls
 
       assert length(callback_calls) == 1
       assert result == 10
       assert intercepted_mfa == {InterceptedOnBefore3, :other_to_intercept, 1}
+      assert arg_values == [4]
     end
 
     test "it doesn't intercept the function that isn't configured" do


### PR DESCRIPTION
Currently working for the selected unit test. Still hardcoding the arg
names (`[:w]` in this case).

A lot still needs to be done, but proves our hypothesis.