### PR TITLE
Feature/pass intercepted function args to callback

### DIFF
--- a/lib/configuration.ex
+++ b/lib/configuration.ex
@@ -11,6 +11,12 @@ defmodule Interceptor.Configuration do
     end
   end
 
+  def get_interceptor_module_function_for({module, function, args} = _to_intercept, interception_type) when is_list(args) do
+    mfa_to_intercept = {module, function, length(args)}
+
+    get_interceptor_module_function_for(mfa_to_intercept, interception_type)
+  end
+
   def get_interceptor_module_function_for({module, _function, _arity} = to_intercept, interception_type) do
     interception_configuration = get_configuration(module)
     configuration = interception_configuration[to_intercept]

--- a/lib/function_arguments.ex
+++ b/lib/function_arguments.ex
@@ -1,0 +1,96 @@
+defmodule Interceptor.FunctionArguments do
+  alias Interceptor.Utils
+
+  @doc """
+  Use this function to get a tuple containing a list with the names
+  of the function arguments and the list of the arguments in AST form.
+
+  For the function `def abcd(a, b, c), do: 123` you would get:
+
+  ```
+  {
+    [:a, :b, :c],
+    [{:a, [], Elixir}, {:b, [], Elixir}, {:c, [], Elixir}]
+  }
+  ```
+
+  For a function with one or more "anonymous" arguments, this function
+  will assign each argument like this to a random variable.
+
+  For the function `def foo(x, y, {bar}), do: 42` it would return:
+
+  ```
+  {
+    [:x, :y, :a1b2c3d],
+    [
+      {:x, [], Elixir},
+      {:y, [], Elixir},
+      {:=, [], [{:{}, [], [{:bar, [], Elixir}]}, {:a1b2c3d, [], Elixir}]}
+    ]
+  }
+  ```
+
+  Notice the last assignment to the `a1b2c3d` random variable, returning
+  the argument list in AST form as if the
+  the function was defined like `def foo(x, y, {bar} = a1b2c3d), do: 42`.
+  """
+  def get_args_names_and_new_args_list(
+    {_function_name, _metadata, args_list} = _function_hdr, module) do
+      args_list
+      |> Enum.map(&get_arg_name_and_its_ast(&1, module))
+      |> Enum.unzip()
+  end
+
+  defp get_arg_name_and_its_ast({:=, _, [_operand_a, _operand_b] = assignment_operands} = arg_full_ast, _module) do
+    arg_variable = assignment_operands
+    |> Enum.filter(&is_variable(&1))
+    |> hd()
+
+    {arg_name, _, _} = arg_variable
+
+    {arg_name, arg_full_ast}
+  end
+
+  defp get_arg_name_and_its_ast({:\\, _metadata, [arg_ast, _default_value_ast]} = arg_full_ast, _module) do
+    {arg_name, _, _} = arg_ast
+
+    {arg_name, arg_full_ast}
+  end
+
+  # in this case, `arg_ast` doesn't contain an assignment, so we are "manually"
+  # placing it inside an assignment statement
+  defp get_arg_name_and_its_ast({arg_name, _metadata, _context} = arg_ast, module)
+    when arg_name in [:<<>>, :{}, :%{}] do
+    random_name = Utils.random_atom()
+    random_variable = Macro.var(random_name, module)
+
+    # if value_ast represents `{a,b,c}`, the
+    # returned assignment (in AST form) will be like
+    # `{a,b,c} = random_variable`
+    assignment_ast = {:=, [], [arg_ast, random_variable]}
+
+    {random_name, assignment_ast}
+  end
+
+  defp get_arg_name_and_its_ast({arg_name, _metadata, _context} = arg_ast, _module)
+    when is_atom(arg_name) do
+    {arg_name, arg_ast}
+  end
+
+  defp get_arg_name_and_its_ast(arg_ast, module) when is_list(arg_ast) do
+    random_name = Utils.random_atom()
+    random_variable = Macro.var(random_name, module)
+
+    # if value_ast represents `[a,b,c]`, the
+    # returned assignment (in AST form) will be like
+    # `[a,b,c] = random_variable`
+    assignment_ast = {:=, [], [arg_ast, random_variable]}
+
+    {random_name, assignment_ast}
+  end
+
+  defp is_variable({name, metadata, context})
+    when is_atom(name) and is_list(metadata) and is_atom(context), do: true
+
+  defp is_variable(_other_ast), do: false
+end

--- a/lib/interceptor.ex
+++ b/lib/interceptor.ex
@@ -1,10 +1,13 @@
 defmodule Interceptor do
   @moduledoc """
   The Interceptor library allows you to intercept function calls, by configuring
-  the interception functions and using the `Interceptor.intercept/1` macro.
+  your interception functions and using the `Interceptor.intercept/1` macro.
 
   Create a module with a `get_intercept_config/0` function that returns the
   interception configuration map.
+
+  In the example below, the `Intercepted.abc/1` function will be intercepted
+  *before* it starts, *after* it ends, and when it concludes successfully or not:
 
   ```
   defmodule Interception.Config do
@@ -28,31 +31,30 @@ defmodule Interceptor do
       configuration: Interception.Config
   ```
 
-  Define your interceptor module:
+  Define the callback functions that will be called during the execution of your intercepted functions:
 
   ```
   defmodule MyInterceptor do
-    def intercept_before(mfa),
-      do: IO.puts "Intercepted \#\{inspect(mfa)\} before it started."
+    def intercept_before(mfargs),
+      do: IO.puts "Intercepted \#\{inspect(mfargs)\} before it started."
 
-    def intercept_after(mfa, result),
-      do: IO.puts "Intercepted \#\{inspect(mfa)\} after it completed. Its result: \#\{inspect(result)\}"
+    def intercept_after(mfargs, result),
+      do: IO.puts "Intercepted \#\{inspect(mfargs)\} after it completed. Its result: \#\{inspect(result)\}"
 
-    def intercept_on_success(mfa, result, _start_timestamp),
-      do: IO.puts "Intercepted \#\{inspect(mfa)\} after it completed successfully. Its result: \#\{inspect(result)\}"
+    def intercept_on_success(mfargs, result, _start_timestamp),
+      do: IO.puts "Intercepted \#\{inspect(mfargs)\} after it completed successfully. Its result: \#\{inspect(result)\}"
 
-    def intercept_on_error(mfa, error, _start_timestamp),
-      do: IO.puts "Intercepted \#\{inspect(mfa)\} after it raised an error. Here's the error: \#\{inspect(error)\}"
+    def intercept_on_error(mfargs, error, _start_timestamp),
+      do: IO.puts "Intercepted \#\{inspect(mfargs)\} after it raised an error. Here's the error: \#\{inspect(error)\}"
   end
   ```
 
-  In the module that you want to intercept (in our case, `Intercepted`), place the
-  functions that you want to intercept inside an `Interceptor.intercept/1` block.
+  Finally, wrap the functions to intercept with an `Interceptor.intercept/1` block
+  (`Interceptor.intercept/1` is actually a macro). Notice that if your functions
+  are placed outside of this block or if they don't have a corresponding interceptor
+  configuration, they won't be intercepted.
 
-  Notice that if your functions are placed out of this block or if they don't have a
-  corresponding interceptor configuration, they won't be intercepted. In the following
-  example, the `not_intercepted/3` function can't be intercepted because it isn't enclosed
-  in the `Interceptor.intercept/1` block.
+  This is how the `Intercepted` module using the `intercept/1` macro looks like:
 
   ```
   defmodule Intercepted do
@@ -62,43 +64,62 @@ defmodule Interceptor do
       def abc(x), do: "Got \#\{inspect(x)\}"
     end
 
+    # the following function can't be intercepted
+    # because it isn't enclosed in the `Interceptor.intercept/1` block
     def not_intercepted(f, g, h), do: f+g+h
   end
   ```
 
-  Now when you run your code, whenever the `Intercepted.abc/1` function is
-  called, it will be intercepted *before* it starts and *after* it completes.
+  In the previous example, we defined four callbacks:
 
-  In the previous example, we defined four callbacks: one `before` callback, that
-  will be called before the intercepted function starts; one `after` callback, that
-  will be called after the intercepted function completes. And we also defined the
-  `on_success` and `on_error` callbacks, that will be called when the
-  `Intercepted.abc/1` function completes successfully or raises any error,
-  respectively.
+  - a `before` callback, that will be called before the intercepted function starts;
+  - an `after` callback, that will be called after the intercepted function completes;
+  - an `on_success` callback, that will be called if the function completes successfully;
+  - an `on_error` callback, that will be called if the function raises any error.
+
+  Now when you run your code, whenever the `Intercepted.abc/1` function is
+  called, it will be intercepted *before* it starts, *after* it completes,
+  when it completes *successfully* or when it *raises* an error.
+
+  You can also intercept private functions in the exact same way you intercept
+  public functions. You just need to configure the callbacks that should be invoked for
+  the given private function, and the private function definition needs to be enclosed in
+  an `Interceptor.intercept/1` macro.
+
+  ### MFA passed to your callbacks
+
+  Every function callback that you define will receive as its first argument a "MFArgs"
+  tuple, i.e., `{intercepted_module, intercepted_function, intercepted_args}`.
+  The `intercepted_args` is a list of arguments passed to your intercepted function.
+  Even if your intercepted function only receives a single argument, `intercepted_args`
+  will still be a list with a single element.
+
+  *Pro-tip*: Since your callback function receives the arguments that the intercepted
+  function received, you can pattern match on the argument values function. ⚠️  Just
+  have in mind that if your `intercepted_args` don't pattern match the values your
+  callback function expects, you'll get an error every time your callback function
+  does its thing and intercepts the function.
+
+  ### Wrapper callback (aka build your custom callback)
 
   If none of the previous callbacks suits your needs, you can use the `wrapper`
   callback. This way, the intercepted function will be wrapped in a lambda and
   passed to your callback function.
 
-  _Note:_ When you use a `wrapper` callback, you can't use any other callback,
+  When you use a `wrapper` callback, you can't use any other callback,
   i.e., the `before`, `after`, `on_success` and `on_error` callbacks can't be
   used for a function that is already being intercepted by a `wrapper` callback.
   If you try so, an exception in compile-time will be raised.
 
-  _Note 2:_ When you use the `wrapper` callback, it's the responsibility of the
+  When you use the `wrapper` callback, it's the responsibility of the
   callback function to invoke the lambda and return the result. If you don't
   return the result from your callback, the return value of the intercepted
   function will be whatever value your `wrapper` callback function returns.
 
-  _Note 3:_ You can intercept private functions in exactly the same way you intercept
-  public functions. You just need to configure the callbacks that should be invoked for
-  the given private function, and the private function definition needs to be enclosed in
-  an `Interceptor.intercept/1` macro.
-
   ## Possible callbacks
 
   * `before` - The callback function that you use to intercept your function
-  will be passed the MFA (`{intercepted_module, intercepted_function,
+  will be passed the MFArgs (`{intercepted_module, intercepted_function,
   intercepted_args}`) of the intercepted function, hence it needs to receive
   *one* argument. E.g.:
 
@@ -111,7 +132,7 @@ defmodule Interceptor do
   ```
 
   * `after` - The callback function that you use to intercept your function
-  will be passed the MFA (`{intercepted_module, intercepted_function,
+  will be passed the MFArgs (`{intercepted_module, intercepted_function,
   intercepted_args}`) of the intercepted function and its result, hence it needs
   to receive *two* arguments. E.g.:
 
@@ -124,7 +145,7 @@ defmodule Interceptor do
   ```
 
   * `on_success` - The callback function that you use to intercept your function
-  on success will be passed the MFA (`{intercepted_module, intercepted_function,
+  on success will be passed the MFArgs (`{intercepted_module, intercepted_function,
   intercepted_args}`) of the intercepted function, its success result and the
   start timestamp (in microseconds, obtained with
   `:os.system_time(:microsecond)`), hence it needs to receive *three* arguments.
@@ -140,7 +161,7 @@ defmodule Interceptor do
   ```
 
   * `on_error` - The callback function that you use to intercept your function
-  on error will be passed the MFA (`{intercepted_module, intercepted_function,
+  on error will be passed the MFArgs (`{intercepted_module, intercepted_function,
   intercepted_args}`) of the intercepted function, the raised error and the
   start timestamp (in microseconds, obtained with
   `:os.system_time(:microsecond)`), hence it needs to receive *three* arguments.
@@ -156,9 +177,9 @@ defmodule Interceptor do
   ```
 
   * `wrapper` - The callback function that you use to intercept your function
-  will be passed the MFA (`{intercepted_module, intercepted_function,
+  will be passed the MFArgs (`{intercepted_module, intercepted_function,
   intercepted_args}`) of the intercepted function and its body wrapped in a
-  lambda, hence it needs to receive *two* argument. E.g.:
+  lambda, hence it needs to receive *two* arguments. E.g.:
 
   ```
   defmodule WrapperInterceptor do
@@ -174,13 +195,13 @@ defmodule Interceptor do
 
   ## Streamlined configuration
 
-  If you think defining a `get_intercept_config/0` function on the configuration module or
-  using the `{module, function, arity}` format is too verbose, you can use the
-  `Interceptor.Configurator` that will allow you to use its `intercept/2` macro and the
-  `"Module.function/arity"` streamlined format.
+  If you think that defining a `get_intercept_config/0` function on the configuration
+  module or using the `{module, function, arity}` format is too verbose, you can use the
+  `Interceptor.Configurator` module that will allow you to use its `intercept/2` macro
+  and the `"Module.function/arity"` streamlined format.
 
   Using the `Configurator` and the new streamlined format, the previous configuration
-  would become:
+  for the `Intercepted.abc/1` function would become:
 
   ```
   defmodule Interception.Config do
@@ -200,10 +221,10 @@ defmodule Interceptor do
   end
   ```
 
-  The `Configurator` is defining the needed `get_intercept_config/0` for you, and
-  converting those string MFAs into tuple-based MFAs. If you want to intercept another
+  The `Configurator` module is defining the needed `get_intercept_config/0` function for you,
+  and converting those string MFAs into tuple-based MFAs. If you want to intercept another
   function, it's just a matter of adding other `intercept
-  "OtherModule.another_function/2", ...` entry.
+  "OtherModule.another_function/2", ...` entry, exactly as we did.
 
   ## Intercept configuration on the intercepted module
 
@@ -224,11 +245,12 @@ defmodule Interceptor do
   end
   ```
 
-  Note: If the configuration you set on the intercepted module overlaps with a
+  _Note1:_ If the configuration you set on the intercepted module overlaps with a
   configuration set on the application configuration file, the former will take
   precedence, i.e., if both the intercepted module configuration and the application
-  configuration set the rules to intercept the `Intercepted.abc/1` function, the former
-  will prevail, overriding the latter.
+  configuration set the rules to intercept the `Intercepted.abc/1` function, the
+  rules set on the intercepted module will prevail, overriding the rules set on
+  the application configuration file.
 
   Instead of pointing to the intercept configuration module, you may also pass the
   intercept configuration directly via the `config` keyword. E.g:
@@ -332,7 +354,6 @@ defmodule Interceptor do
   defp add_calls({type, _metadata, [function_hdr | [[do: function_body]]]} = function, current_module) when type in [:def, :defp] do
     {new_function_hdr, args_names} = get_function_header_with_new_args_names(function_hdr)
     mfargs = get_mfargs(current_module, function_hdr, args_names)
-
 
     new_function_body = function_body
     |> set_before_callback(mfargs)

--- a/lib/interceptor.ex
+++ b/lib/interceptor.ex
@@ -323,14 +323,14 @@ defmodule Interceptor do
   defp add_calls({type, _metadata, [function_hdr | [[do: function_body]]]} = function, current_module) when type in [:def, :defp] do
     mfa = get_mfa(current_module, function_hdr)
 
-    function_body = function_body
+    new_function_body = function_body
     |> set_before_callback(mfa)
     |> set_after_callback(mfa)
     |> set_on_success_error_callback(mfa)
     |> set_lambda_wrapper(mfa)
 
     function
-    |> put_elem(2, [function_hdr | [[do: function_body]]])
+    |> put_elem(2, [function_hdr | [[do: new_function_body]]])
     |> return_function_body()
   end
 

--- a/lib/interceptor.ex
+++ b/lib/interceptor.ex
@@ -330,7 +330,7 @@ defmodule Interceptor do
   end
 
   defp add_calls({type, _metadata, [function_hdr | [[do: function_body]]]} = function, current_module) when type in [:def, :defp] do
-    {new_function_hdr, args_names} = get_function_header_with_new_args_names(function_hdr, current_module)
+    {new_function_hdr, args_names} = get_function_header_with_new_args_names(function_hdr)
     mfargs = get_mfargs(current_module, function_hdr, args_names)
 
 
@@ -353,7 +353,7 @@ defmodule Interceptor do
     case debug_mode?() do
       true ->
         IO.puts("############# Function AST after interceptor ###")
-        IO.inspect(function_body)
+        IO.inspect(function_body, limit: :infinity)
       _ -> function_body
     end
   end

--- a/test/function_arguments_test.exs
+++ b/test/function_arguments_test.exs
@@ -5,14 +5,14 @@ defmodule FunctionArgumentsTest do
   describe "gets each argument name and the corresponding value (in AST form)" do
     test "it handles no arguments" do
       function_header = get_function_header("def abc(), do: 123")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       assert {[], []} == result
     end
 
     test "it handles simple arguments" do
       function_header = get_function_header("def abc(x, y, z), do: x+y+z")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -29,7 +29,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles tuple destructure" do
       function_header = get_function_header("def abc({x, y, z}), do: x+y+z")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -47,7 +47,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles binary destructure" do
       function_header = get_function_header("def abc(<<x, y, z>>), do: [x,y,z]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -65,7 +65,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles map destructure" do
       function_header = get_function_header("def abc(%{a: x, b: y, c: z}), do: [x,y,z]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -83,7 +83,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles keyword list destructure" do
       function_header = get_function_header("def abc([a: x, b: y, c: z]), do: [x,y,z]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -101,7 +101,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles list destructure (one element)" do
       function_header = get_function_header("def abc([x]), do: [x]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -119,7 +119,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles list destructure (more than one element)" do
       function_header = get_function_header("def abc([x,y,z]), do: [x,y,z]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -137,7 +137,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles existing assignments (variable first)" do
       function_header = get_function_header("def abc(a = {bar}), do: [a, bar]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -151,7 +151,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles existing assignments (variable after)" do
       function_header = get_function_header("def abc({bar} = foo), do: [foo, bar]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -165,7 +165,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles default values (nil)" do
       function_header = get_function_header("def abc(foo \\\\ nil), do: [foo]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -179,7 +179,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles default values (123)" do
       function_header = get_function_header("def abc(bar \\\\ 123), do: [bar]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 
@@ -193,7 +193,7 @@ defmodule FunctionArgumentsTest do
 
     test "it handles default values (strings)" do
       function_header = get_function_header("def abc(baz \\\\ \"blabla\"), do: [baz]")
-      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header)
 
       {args_names, args_ast} = result
 

--- a/test/function_arguments_test.exs
+++ b/test/function_arguments_test.exs
@@ -1,0 +1,231 @@
+defmodule FunctionArgumentsTest do
+  use ExUnit.Case
+  alias Interceptor.FunctionArguments
+
+  describe "gets each argument name and the corresponding value (in AST form)" do
+    test "it handles no arguments" do
+      function_header = get_function_header("def abc(), do: 123")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      assert {[], []} == result
+    end
+
+    test "it handles simple arguments" do
+      function_header = get_function_header("def abc(x, y, z), do: x+y+z")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert args_names == [:x, :y, :z]
+      assert length(args_ast) == 3
+
+      expected_args_ast = args_names
+                          |> Enum.map(&Macro.var(&1, nil))
+
+      args_ast
+      |> Enum.zip(expected_args_ast)
+      |> Enum.each(&assert_ast_match(&1))
+    end
+
+    test "it handles tuple destructure" do
+      function_header = get_function_header("def abc({x, y, z}), do: x+y+z")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert length(args_names) == length(args_ast)
+      assert length(args_ast) == 1
+
+      [{:=, _metadata, [arg_ast, random_var_ast]}] = args_ast
+
+      expected_arg_ast = quote do: {x, y, z}
+      expected_random_var_ast = Macro.var(hd(args_names), nil)
+
+      assert_ast_match(arg_ast, expected_arg_ast)
+      assert_ast_match(random_var_ast, expected_random_var_ast)
+    end
+
+    test "it handles binary destructure" do
+      function_header = get_function_header("def abc(<<x, y, z>>), do: [x,y,z]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert length(args_names) == length(args_ast)
+      assert length(args_ast) == 1
+
+      [{:=, _metadata, [arg_ast, random_var_ast]}] = args_ast
+
+      expected_arg_ast = quote do: <<x, y, z>>
+      expected_random_var_ast = Macro.var(hd(args_names), nil)
+
+      assert_ast_match(arg_ast, expected_arg_ast)
+      assert_ast_match(random_var_ast, expected_random_var_ast)
+    end
+
+    test "it handles map destructure" do
+      function_header = get_function_header("def abc(%{a: x, b: y, c: z}), do: [x,y,z]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert length(args_names) == length(args_ast)
+      assert length(args_ast) == 1
+
+      [{:=, _metadata, [arg_ast, random_var_ast]}] = args_ast
+
+      expected_arg_ast = quote do: %{a: x, b: y, c: z}
+      expected_random_var_ast = Macro.var(hd(args_names), nil)
+
+      assert_ast_match(arg_ast, expected_arg_ast)
+      assert_ast_match(random_var_ast, expected_random_var_ast)
+    end
+
+    test "it handles keyword list destructure" do
+      function_header = get_function_header("def abc([a: x, b: y, c: z]), do: [x,y,z]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert length(args_names) == length(args_ast)
+      assert length(args_ast) == 1
+
+      [{:=, _metadata, [arg_ast, random_var_ast]}] = args_ast
+
+      expected_arg_ast = quote do: [a: x, b: y, c: z]
+      expected_random_var_ast = Macro.var(hd(args_names), nil)
+
+      assert_ast_match(arg_ast, expected_arg_ast)
+      assert_ast_match(random_var_ast, expected_random_var_ast)
+    end
+
+    test "it handles list destructure (one element)" do
+      function_header = get_function_header("def abc([x]), do: [x]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert length(args_names) == length(args_ast)
+      assert length(args_ast) == 1
+
+      [{:=, _metadata, [arg_ast, random_var_ast]}] = args_ast
+
+      expected_arg_ast = quote do: [x]
+      expected_random_var_ast = Macro.var(hd(args_names), nil)
+
+      assert_ast_match(arg_ast, expected_arg_ast)
+      assert_ast_match(random_var_ast, expected_random_var_ast)
+    end
+
+    test "it handles list destructure (more than one element)" do
+      function_header = get_function_header("def abc([x,y,z]), do: [x,y,z]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert length(args_names) == length(args_ast)
+      assert length(args_ast) == 1
+
+      [{:=, _metadata, [arg_ast, random_var_ast]}] = args_ast
+
+      expected_arg_ast = quote do: [x,y,z]
+      expected_random_var_ast = Macro.var(hd(args_names), nil)
+
+      assert_ast_match(arg_ast, expected_arg_ast)
+      assert_ast_match(random_var_ast, expected_random_var_ast)
+    end
+
+    test "it handles existing assignments (variable first)" do
+      function_header = get_function_header("def abc(a = {bar}), do: [a, bar]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert args_names == [:a]
+      assert length(args_ast) == 1
+
+      expected_arg_ast = quote do: a = {bar}
+
+      assert_ast_match(hd(args_ast), expected_arg_ast)
+    end
+
+    test "it handles existing assignments (variable after)" do
+      function_header = get_function_header("def abc({bar} = foo), do: [foo, bar]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert args_names == [:foo]
+      assert length(args_ast) == 1
+
+      expected_arg_ast = quote do: {bar} = foo
+
+      assert_ast_match(hd(args_ast), expected_arg_ast)
+    end
+
+    test "it handles default values (nil)" do
+      function_header = get_function_header("def abc(foo \\\\ nil), do: [foo]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert args_names == [:foo]
+      assert length(args_ast) == 1
+
+      expected_arg_ast = quote do: foo \\ nil
+
+      assert_ast_match(hd(args_ast), expected_arg_ast)
+    end
+
+    test "it handles default values (123)" do
+      function_header = get_function_header("def abc(bar \\\\ 123), do: [bar]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert args_names == [:bar]
+      assert length(args_ast) == 1
+
+      expected_arg_ast = quote do: bar \\ 123
+
+      assert_ast_match(hd(args_ast), expected_arg_ast)
+    end
+
+    test "it handles default values (strings)" do
+      function_header = get_function_header("def abc(baz \\\\ \"blabla\"), do: [baz]")
+      result = FunctionArguments.get_args_names_and_new_args_list(function_header, IrrelevantModule)
+
+      {args_names, args_ast} = result
+
+      assert args_names == [:baz]
+      assert length(args_ast) == 1
+
+      expected_arg_ast = quote do: baz \\ "blabla"
+
+      assert_ast_match(hd(args_ast), expected_arg_ast)
+    end
+  end
+
+  def assert_ast_match({
+    {_arg_name, _arg_metadata, _arg_context} = ast,
+    {_expected_arg_name, _expected_arg_metadata, _expected_arg_context} = expected
+  }), do: assert_ast_match(ast, expected)
+
+  def assert_ast_match(
+    {arg_name, _arg_metadata, _arg_context} = ast,
+    {expected_arg_name, _expected_arg_metadata, _expected_arg_context} = expected) do
+      assert arg_name == expected_arg_name
+
+      assert Macro.to_string(ast) == Macro.to_string(expected)
+    end
+
+  def assert_ast_match(ast, expected) when is_list(ast) and is_list(expected) do
+      assert Macro.to_string(ast) == Macro.to_string(expected)
+  end
+
+  defp get_function_header(def_function_statement) do
+    {:def, _metadata, [function_header | [[do: _function_body]]]} = Code.string_to_quoted!(def_function_statement)
+
+    function_header
+  end
+end

--- a/test/intercepted_modules/intercept_config.ex
+++ b/test/intercepted_modules/intercept_config.ex
@@ -18,6 +18,7 @@ defmodule InterceptConfig do
   {InterceptedOnSuccess2, :to_intercept, 0} => [on_success: {OnSuccess.Callback, :on_success, 3}],
   {InterceptedOnSuccess2, :other_to_intercept, 0} => [on_success: {OnSuccess.Callback, :on_success, 3}],
   {InterceptedOnSuccess3, :other_to_intercept, 1} => [on_success: {OnSuccess.Callback, :on_success, 3}],
+  {InterceptedOnSuccess3, :trickier_args_function, 6} => [on_success: {OnSuccess.Callback, :on_success, 3}],
 
   # on error tests
   {InterceptedOnError1, :to_intercept, 0} => [on_error: {OnError.Callback, :on_error, 3}],

--- a/test/intercepted_modules/intercepted_by_wrapper.ex
+++ b/test/intercepted_modules/intercepted_by_wrapper.ex
@@ -1,5 +1,5 @@
 defmodule Wrapper.Callback do
-  def wrap_returns_result({_module, _function, _arity} = mfa, lambda) do
+  def wrap_returns_result({_module, _function, _args} = mfa, lambda) do
     result = lambda.()
 
     Agent.update(:wrapper_test_process,
@@ -10,7 +10,7 @@ defmodule Wrapper.Callback do
     result
   end
 
-  def wrap_returns_hello({_module, _function, _arity} = mfa, lambda) do
+  def wrap_returns_hello({_module, _function, _args} = mfa, lambda) do
     result = lambda.()
 
     Agent.update(:wrapper_test_process,

--- a/test/intercepted_modules/intercepted_on_after.ex
+++ b/test/intercepted_modules/intercepted_on_after.ex
@@ -1,5 +1,5 @@
 defmodule After.Callback do
-  def right_after({_module, _function, _arity} = mfa, result) do
+  def right_after({_module, _function, _args} = mfa, result) do
     Agent.update(:after_test_process,
       fn messages ->
         [{Interceptor.Utils.timestamp(), result, mfa} | messages]

--- a/test/intercepted_modules/intercepted_on_after_own_configuration.ex
+++ b/test/intercepted_modules/intercepted_on_after_own_configuration.ex
@@ -1,5 +1,5 @@
 defmodule After.OwnCallback do
-  def right_after({_module, _function, _arity} = mfa, result) do
+  def right_after({_module, _function, _args} = mfa, result) do
     Agent.update(:after_test_process,
       fn messages ->
         [{:callback_overridden, result, mfa} | messages]

--- a/test/intercepted_modules/intercepted_on_before.ex
+++ b/test/intercepted_modules/intercepted_on_before.ex
@@ -1,5 +1,5 @@
 defmodule Before.Callback do
-  def before({_module, _function, _arity} = mfa) do
+  def before({_module, _function, _args} = mfa) do
     Agent.update(:before_test_process,
       fn messages ->
         [{Interceptor.Utils.timestamp(), mfa} | messages]

--- a/test/intercepted_modules/intercepted_on_error.ex
+++ b/test/intercepted_modules/intercepted_on_error.ex
@@ -1,5 +1,5 @@
 defmodule OnError.Callback do
-  def on_error({_module, _function, _arity} = mfa, result, started_at) do
+  def on_error({_module, _function, _args} = mfa, result, started_at) do
     Agent.update(:on_error_test_process,
       fn messages ->
         [{started_at, Interceptor.Utils.timestamp(), result, mfa} | messages]

--- a/test/intercepted_modules/intercepted_on_success.ex
+++ b/test/intercepted_modules/intercepted_on_success.ex
@@ -37,5 +37,21 @@ defmodule InterceptedOnSuccess3 do
     def other_to_intercept(w), do: w + private_function(1, 2, 3)
 
     defp private_function(x, y, z), do: x+y+z
+
+    def trickier_args_function(first_arg, [one, two, three], {abc, xyz}, %{baz: woz}, <<g,h,i>>, foo \\ "bar") do
+      [
+        first_arg,
+        one,
+        two,
+        three,
+        abc,
+        xyz,
+        woz,
+        g,
+        h,
+        i,
+        foo
+      ]
+    end
   end
 end

--- a/test/intercepted_modules/intercepted_on_success.ex
+++ b/test/intercepted_modules/intercepted_on_success.ex
@@ -1,5 +1,5 @@
 defmodule OnSuccess.Callback do
-  def on_success({_module, _function, _arity} = mfa, result, started_at) do
+  def on_success({_module, _function, _args} = mfa, result, started_at) do
     Agent.update(:on_success_test_process,
       fn messages ->
         [{started_at, Interceptor.Utils.timestamp(), result, mfa} | messages]

--- a/test/intercepted_modules/intercepted_private_on_success_on_error_own_configuration.ex
+++ b/test/intercepted_modules/intercepted_private_on_success_on_error_own_configuration.ex
@@ -1,5 +1,5 @@
 defmodule OwnCallbacks do
-  def on_success({_module, _function, _arity} = mfa, result, started_at) do
+  def on_success({_module, _function, _args} = mfa, result, started_at) do
     Agent.update(:private_on_success_test_process,
       fn messages ->
         [{started_at, Interceptor.Utils.timestamp(), result, mfa} | messages]
@@ -7,7 +7,7 @@ defmodule OwnCallbacks do
     "Yo, I don't influence anything"
   end
 
-  def on_error({_module, _function, _arity} = mfa, error, started_at) do
+  def on_error({_module, _function, _args} = mfa, error, started_at) do
     Agent.update(:private_on_error_test_process,
       fn messages ->
         [{started_at, Interceptor.Utils.timestamp(), error, mfa} | messages]

--- a/test/intercepted_modules/minefield.ex
+++ b/test/intercepted_modules/minefield.ex
@@ -1,18 +1,18 @@
 defmodule Outsider do
   # used when we want to intercept *before* the function starts
-  def before({_module, _function, _arity} = mfa) do
+  def before({_module, _function, _args} = mfa) do
     IO.puts("BEFORE #{inspect(mfa)}")
     42
   end
 
   # used when we want to intercept *after* the function completes
-  def right_after({_module, _function, _arity} = mfa, result) do
+  def right_after({_module, _function, _args} = mfa, result) do
     IO.puts("AFTER #{inspect(mfa)}")
     IO.puts("AFTER #{inspect(result)}")
     42
   end
 
-  def on_success({_module, _function, _arity} = mfa, result, started_at_microseconds \\ nil) do
+  def on_success({_module, _function, _args} = mfa, result, started_at_microseconds \\ nil) do
     time_it_took = case started_at_microseconds do
       nil -> "I don't know"
       _ -> :os.system_time(:microsecond) - started_at_microseconds
@@ -21,7 +21,7 @@ defmodule Outsider do
     IO.puts("IT WORKED #{inspect(mfa)}, took #{time_it_took} light-years. Here's the result #{inspect(result)}")
   end
 
-  def on_error({_module, _function, _arity} = mfa, error, started_at_microseconds \\ nil) do
+  def on_error({_module, _function, _args} = mfa, error, started_at_microseconds \\ nil) do
     time_it_took = case started_at_microseconds do
       nil -> "I don't know"
       _ -> :os.system_time(:microsecond) - started_at_microseconds
@@ -30,7 +30,7 @@ defmodule Outsider do
     IO.puts("IT failed miserably #{inspect(mfa)}, took #{time_it_took} light-years. Here's the error #{inspect(error)}")
   end
 
-  def wrapper({_module, _function, _arity} = mfa, lambda) do
+  def wrapper({_module, _function, _args} = mfa, lambda) do
     result = lambda.()
     IO.puts("[#{inspect(mfa)}] INSIDE wrapper #{inspect(result)}")
     result

--- a/test/interceptor_on_after_own_configuration_test.exs
+++ b/test/interceptor_on_after_own_configuration_test.exs
@@ -15,7 +15,7 @@ defmodule InterceptorOnAfterOwnConfigurationTest do
 
       assert length(callback_calls) == 1
       assert result == callback_result
-      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration1, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration1, :to_intercept, []}
     end
   end
 
@@ -31,7 +31,7 @@ defmodule InterceptorOnAfterOwnConfigurationTest do
 
       assert length(callback_calls) == 1
       assert result == callback_result
-      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration2, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration2, :to_intercept, []}
     end
   end
 
@@ -47,7 +47,7 @@ defmodule InterceptorOnAfterOwnConfigurationTest do
 
       assert length(callback_calls) == 1
       assert result == callback_result
-      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration3, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration3, :to_intercept, []}
     end
   end
 
@@ -63,7 +63,7 @@ defmodule InterceptorOnAfterOwnConfigurationTest do
 
       assert length(callback_calls) == 1
       assert result == callback_result
-      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration4, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfterOwnConfiguration4, :to_intercept, []}
     end
   end
 

--- a/test/interceptor_on_after_test.exs
+++ b/test/interceptor_on_after_test.exs
@@ -15,7 +15,7 @@ defmodule InterceptorOnAfterTest do
 
       assert length(callback_calls) == 1
       assert result == callback_result
-      assert intercepted_mfa == {InterceptedOnAfter1, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfter1, :to_intercept, []}
     end
   end
 
@@ -32,7 +32,7 @@ defmodule InterceptorOnAfterTest do
       assert length(callback_calls) == 1
       assert result == callback_result
       assert result < intercepted_timestamp
-      assert intercepted_mfa == {InterceptedOnAfter2, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfter2, :to_intercept, []}
     end
 
     test "it also intercepts the other function" do
@@ -47,7 +47,7 @@ defmodule InterceptorOnAfterTest do
       assert length(callback_calls) == 1
       assert result == callback_result
       assert result == "HELLO"
-      assert intercepted_mfa == {InterceptedOnAfter2, :other_to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnAfter2, :other_to_intercept, []}
     end
   end
 
@@ -64,7 +64,7 @@ defmodule InterceptorOnAfterTest do
       assert length(callback_calls) == 1
       assert result == result_callback
       assert result == 10
-      assert intercepted_mfa == {InterceptedOnAfter3, :other_to_intercept, 1}
+      assert intercepted_mfa == {InterceptedOnAfter3, :other_to_intercept, [4]}
     end
 
     test "it doesn't intercept the function that isn't configured" do

--- a/test/interceptor_on_before_test.exs
+++ b/test/interceptor_on_before_test.exs
@@ -15,7 +15,7 @@ defmodule InterceptorOnBeforeTest do
 
       assert length(callback_calls) == 1
       assert result > intercepted_timestamp
-      assert intercepted_mfa == {InterceptedOnBefore1, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnBefore1, :to_intercept, []}
     end
   end
 
@@ -31,7 +31,7 @@ defmodule InterceptorOnBeforeTest do
 
       assert length(callback_calls) == 1
       assert result > intercepted_timestamp
-      assert intercepted_mfa == {InterceptedOnBefore2, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnBefore2, :to_intercept, []}
     end
 
     test "it also intercepts the other function" do
@@ -45,7 +45,7 @@ defmodule InterceptorOnBeforeTest do
 
       assert length(callback_calls) == 1
       assert result == "HELLO"
-      assert intercepted_mfa == {InterceptedOnBefore2, :other_to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnBefore2, :other_to_intercept, []}
     end
   end
 
@@ -61,7 +61,7 @@ defmodule InterceptorOnBeforeTest do
 
       assert length(callback_calls) == 1
       assert result == 10
-      assert intercepted_mfa == {InterceptedOnBefore3, :other_to_intercept, 1}
+      assert intercepted_mfa == {InterceptedOnBefore3, :other_to_intercept, [4]}
     end
 
     test "it doesn't intercept the function that isn't configured" do
@@ -90,7 +90,7 @@ defmodule InterceptorOnBeforeTest do
 
       assert length(callback_calls) == 1
       assert result == "Hello, even without args"
-      assert intercepted_mfa == {InterceptedOnBefore4, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnBefore4, :to_intercept, []}
     end
   end
 

--- a/test/interceptor_on_error_test.exs
+++ b/test/interceptor_on_error_test.exs
@@ -22,7 +22,7 @@ defmodule InterceptorOnErrorTest do
 
       assert length(callback_calls) == 1
       assert %ArithmeticError{} == intercepted_error
-      assert intercepted_mfa == {InterceptedOnError1, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnError1, :to_intercept, []}
     end
   end
 
@@ -51,7 +51,7 @@ defmodule InterceptorOnErrorTest do
       time_it_took_microseconds = intercepted_timestamp - started_at_timestamp
       assert 200_000 < time_it_took_microseconds
       assert %ArithmeticError{} == intercepted_error
-      assert intercepted_mfa == {InterceptedOnError2, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnError2, :to_intercept, []}
     end
 
     test "it also intercepts the other function" do
@@ -71,7 +71,7 @@ defmodule InterceptorOnErrorTest do
       }] = callback_calls
 
       assert length(callback_calls) == 1
-      assert intercepted_mfa == {InterceptedOnError2, :other_to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnError2, :other_to_intercept, []}
     end
   end
 
@@ -93,7 +93,7 @@ defmodule InterceptorOnErrorTest do
       }] = callback_calls
 
       assert length(callback_calls) == 1
-      assert intercepted_mfa == {InterceptedOnError3, :other_to_intercept, 1}
+      assert intercepted_mfa == {InterceptedOnError3, :other_to_intercept, [4]}
     end
 
     test "it doesn't intercept the function that isn't configured" do

--- a/test/interceptor_on_success_test.exs
+++ b/test/interceptor_on_success_test.exs
@@ -21,7 +21,7 @@ defmodule InterceptorOnSuccessTest do
       assert length(callback_calls) == 1
       assert result == intercepted_result
 
-      assert intercepted_mfa == {InterceptedOnSuccess1, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnSuccess1, :to_intercept, []}
     end
   end
 
@@ -48,7 +48,7 @@ defmodule InterceptorOnSuccessTest do
       time_it_took_microseconds = intercepted_timestamp - started_at_timestamp
       assert 200_000 < time_it_took_microseconds
       assert result == intercepted_result
-      assert intercepted_mfa == {InterceptedOnSuccess2, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnSuccess2, :to_intercept, []}
     end
 
     test "it also intercepts the other function" do
@@ -67,7 +67,7 @@ defmodule InterceptorOnSuccessTest do
 
       assert length(callback_calls) == 1
       assert result == "HELLO"
-      assert intercepted_mfa == {InterceptedOnSuccess2, :other_to_intercept, 0}
+      assert intercepted_mfa == {InterceptedOnSuccess2, :other_to_intercept, []}
     end
   end
 
@@ -88,7 +88,7 @@ defmodule InterceptorOnSuccessTest do
 
       assert length(callback_calls) == 1
       assert result == 10
-      assert intercepted_mfa == {InterceptedOnSuccess3, :other_to_intercept, 1}
+      assert intercepted_mfa == {InterceptedOnSuccess3, :other_to_intercept, [4]}
     end
 
     test "it doesn't intercept the function that isn't configured" do

--- a/test/interceptor_on_success_test.exs
+++ b/test/interceptor_on_success_test.exs
@@ -111,7 +111,101 @@ defmodule InterceptorOnSuccessTest do
 
       assert length(callback_calls) == 0
     end
+
+    test "it intercepts the function with 'anonymous' arguments, using the default argument" do
+      {:ok, _pid} = spawn_agent()
+
+      result = InterceptedOnSuccess3.trickier_args_function(
+        :a,
+        [:b, :c, :d],
+        {:e, :f},
+        %{baz: :g},
+        "xyz")
+
+      callback_calls = get_agent_messages()
+
+      [{
+        _started_at_timestamp,
+        _intercepted_timestamp,
+        _intercepted_result,
+        intercepted_mfa
+      }] = callback_calls
+
+      assert length(callback_calls) == 1
+      assert result == [
+        :a,
+        :b,
+        :c,
+        :d,
+        :e,
+        :f,
+        :g,
+        120, # 'x'
+        121, # 'y'
+        122, # 'z'
+        "bar"
+      ]
+
+      expected_arguments = [
+        :a,
+        [:b, :c, :d],
+        {:e, :f},
+        %{baz: :g},
+        "xyz",
+        "bar"
+      ]
+
+      assert intercepted_mfa == {InterceptedOnSuccess3, :trickier_args_function, expected_arguments}
+    end
+
+    test "it intercepts the function with 'anonymous' arguments, and doesn't use a default argument" do
+      {:ok, _pid} = spawn_agent()
+
+      result = InterceptedOnSuccess3.trickier_args_function(
+        :a,
+        [:b, :c, :d],
+        {:e, :f},
+        %{baz: :g},
+        "xyz",
+        "not_default")
+
+      callback_calls = get_agent_messages()
+
+      [{
+        _started_at_timestamp,
+        _intercepted_timestamp,
+        _intercepted_result,
+        intercepted_mfa
+      }] = callback_calls
+
+      assert length(callback_calls) == 1
+      assert result == [
+        :a,
+        :b,
+        :c,
+        :d,
+        :e,
+        :f,
+        :g,
+        120, # 'x'
+        121, # 'y'
+        122, # 'z'
+        "not_default"
+      ]
+
+      expected_arguments = [
+        :a,
+        [:b, :c, :d],
+        {:e, :f},
+        %{baz: :g},
+        "xyz",
+        "not_default"
+      ]
+
+      assert intercepted_mfa == {InterceptedOnSuccess3, :trickier_args_function, expected_arguments}
+    end
   end
+
 
   defp spawn_agent() do
     @process_name

--- a/test/interceptor_private_own_configuration_on_success_error_test.exs
+++ b/test/interceptor_private_own_configuration_on_success_error_test.exs
@@ -22,7 +22,7 @@ defmodule InterceptorPrivateOwnConfigurationOnSuccessErrorTest do
       time_it_took_microseconds = intercepted_timestamp - started_at_timestamp
       assert time_it_took_microseconds > 500_000
 
-      assert intercepted_mfa == {InterceptedPrivateOnSuccessOnErrorOwnConfiguration, :square_plus_10, 1}
+      assert intercepted_mfa == {InterceptedPrivateOnSuccessOnErrorOwnConfiguration, :square_plus_10, [3]}
     end
 
     test "it intercepts the private function after it raises an error" do
@@ -47,7 +47,7 @@ defmodule InterceptorPrivateOwnConfigurationOnSuccessErrorTest do
       time_it_took_microseconds = intercepted_timestamp - started_at_timestamp
       assert time_it_took_microseconds > 600_000
 
-      assert intercepted_mfa == {InterceptedPrivateOnSuccessOnErrorOwnConfiguration, :divide_by_0, 1}
+      assert intercepted_mfa == {InterceptedPrivateOnSuccessOnErrorOwnConfiguration, :divide_by_0, [42]}
     end
   end
 

--- a/test/interceptor_wrapper_test.exs
+++ b/test/interceptor_wrapper_test.exs
@@ -15,7 +15,7 @@ defmodule InterceptorWrapperTest do
 
       assert length(callback_calls) == 1
       assert result == callback_result
-      assert intercepted_mfa == {InterceptedByWrapper1, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedByWrapper1, :to_intercept, []}
     end
   end
 
@@ -32,7 +32,7 @@ defmodule InterceptorWrapperTest do
       assert length(callback_calls) == 1
       assert result == callback_result
       assert intercepted_timestamp > result
-      assert intercepted_mfa == {InterceptedByWrapper2, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedByWrapper2, :to_intercept, []}
     end
 
     test "it also intercepts the other function" do
@@ -47,7 +47,7 @@ defmodule InterceptorWrapperTest do
       assert length(callback_calls) == 1
       assert result == callback_result
       assert result == "HELLO"
-      assert intercepted_mfa == {InterceptedByWrapper2, :other_to_intercept, 0}
+      assert intercepted_mfa == {InterceptedByWrapper2, :other_to_intercept, []}
     end
   end
 
@@ -64,7 +64,7 @@ defmodule InterceptorWrapperTest do
       assert length(callback_calls) == 1
       assert result == result_callback
       assert result == 10
-      assert intercepted_mfa == {InterceptedByWrapper3, :other_to_intercept, 1}
+      assert intercepted_mfa == {InterceptedByWrapper3, :other_to_intercept, [4]}
     end
 
     test "it doesn't intercept the function that isn't configured" do
@@ -94,7 +94,7 @@ defmodule InterceptorWrapperTest do
       assert length(callback_calls) == 1
       assert result != callback_result
       assert result == "Hello"
-      assert intercepted_mfa == {InterceptedByWrapper4, :to_intercept, 0}
+      assert intercepted_mfa == {InterceptedByWrapper4, :to_intercept, []}
     end
   end
 


### PR DESCRIPTION
Passing list of args *values* to every callback functions, instead of the arity of the intercepted function.

This allows the callback functions to pattern match on specific argument values.

The documentation in this branch doesn't reflect this change yet, hence won't merge for now.